### PR TITLE
Subcategories

### DIFF
--- a/beacon/blueprints/beacon_admin.py
+++ b/beacon/blueprints/beacon_admin.py
@@ -58,7 +58,8 @@ def new():
         'beacon/admin/opportunity.html', form=form, opportunity=None,
         subcategories=form.get_subcategories(),
         categories=form.get_categories(),
-        help_blocks=Opportunity.get_help_blocks()
+        help_blocks=Opportunity.get_help_blocks(),
+        selected_subcategories=[i.id for i in form.data['categories']]
     )
 
 @blueprint.route('/opportunities/<int:opportunity_id>', methods=['GET', 'POST'])

--- a/beacon/blueprints/front.py
+++ b/beacon/blueprints/front.py
@@ -116,6 +116,7 @@ def signup():
 
         session['email'] = form.data.get('email')
         session['business_name'] = form.data.get('business_name')
+
         return redirect(url_for('front.splash'))
 
     page_email = request.args.get('email', None)
@@ -136,7 +137,8 @@ def signup():
     return render_template(
         'beacon/front/signup.html', form=form,
         categories=form.get_categories(),
-        subcategories=form.get_subcategories()
+        subcategories=form.get_subcategories(),
+        selected_subcategories=[i.id for i in form.data['categories']]
     )
 
 @blueprint.route('/manage', methods=['GET', 'POST'])

--- a/beacon/static/js/categories.js
+++ b/beacon/static/js/categories.js
@@ -1,111 +1,149 @@
-(function () {
-  'use strict';
+;(function () {
+  'use strict'
 
-  var categoriesContainer = $('#js-categories-container');
-  var addAnother = $('#js-add-category');
-  var categoryId = 1;
+  var categoriesContainer = $('#js-categories-container')
+  var addAnother = $('#js-add-category')
+  var categoryId = 1
 
   function displayNewSubcats (subcatGroup, category) {
-    var newSubcats = subcategories[category];
+    var newSubcats = subcategories[category]
+
     // remove the old radio boxes
-    subcatGroup.children().remove();
+    subcatGroup.children().remove()
 
     // return if we don't have any categories
     if (!newSubcats) {
-      return;
+      return
     }
 
     // otherwise add the new ones
-    var newCheckboxes = '<div class="col-sm-12">' +
-      '<div class="checkbox signup-checkbox">' +
+    if (selectedSubCategories.length > 0) {
+      var newCheckboxes = '<div class="col-sm-12"></div>'
+
+    } else {
+      var newCheckboxes = '<div class="col-sm-12">' +
+        '<div class="checkbox signup-checkbox">' +
         '<input id="check-all-' + categoryId + '" type="checkbox" class="js-uncheck-all" data-checked="true" checked="true" name="check-all">' +
         '<label for="check-all-' + categoryId + '">Check all</label>' +
-      '</div>' +
-    '</div>';
-
-    for (var i = 0; i < newSubcats.length; i++) {
-      newCheckboxes += '<div class="col-sm-12">' +
-        '<div class="checkbox signup-checkbox">' +
-          '<input id="subcategories-' + newSubcats[i][0] + '" class="js-subcategory" name="subcategories-' + newSubcats[i][0] +
-            '" type="checkbox" checked=true>' +
-          '<label for="subcategories-' + newSubcats[i][0] + '">' + newSubcats[i][1] + '</label>' +
         '</div>' +
-      '</div>';
+        '</div>'
     }
 
-    subcatGroup.append(newCheckboxes);
+    for (var i = 0; i < newSubcats.length; i++) {
+      if (($.inArray(newSubcats[i][0], selectedSubCategories) > -1) || (selectedSubCategories.length === 0)) {
+        newCheckboxes += '<div class="col-sm-12">' +
+          '<div class="checkbox signup-checkbox">' +
+          '<input id="subcategories-' + newSubcats[i][0] + '" class="js-subcategory" name="subcategories-' + newSubcats[i][0] +
+          '" type="checkbox" checked=true>' +
+          '<label for="subcategories-' + newSubcats[i][0] + '">' + newSubcats[i][1] + '</label>' +
+          '</div>' +
+          '</div>'
+      } else {
+        newCheckboxes += '<div class="col-sm-12">' +
+          '<div class="checkbox signup-checkbox">' +
+          '<input id="subcategories-' + newSubcats[i][0] + '" class="js-subcategory" name="subcategories-' + newSubcats[i][0] +
+          '" type="checkbox">' +
+          '<label for="subcategories-' + newSubcats[i][0] + '">' + newSubcats[i][1] + '</label>' +
+          '</div>' +
+          '</div>'
 
-    return true;
+      }
+    }
+
+    subcatGroup.append(newCheckboxes)
+
+    return true
   }
 
   function uncheckAll () {
     $('.js-uncheck-all').change(function () {
-      var subcatGroup = $(this).parents('.form-group');
-      var _this = $(this);
+      var subcatGroup = $(this).parents('.form-group')
+      var _this = $(this)
 
       if (_this.attr('data-checked') === 'true') {
-        subcatGroup.find('input:checkbox').prop('checked', false);
-        _this.attr('data-checked', 'false');
+        subcatGroup.find('input:checkbox').prop('checked', false)
+        _this.attr('data-checked', 'false')
 
       } else {
-        subcatGroup.find('input:checkbox').prop('checked', true);
-        _this.attr('data-checked', 'true');
+        subcatGroup.find('input:checkbox').prop('checked', true)
+        _this.attr('data-checked', 'true')
       }
-    });
+    })
   }
 
   function showSubcats (subcatLabel) {
-    var subcatGroup = '#js-subcategory-group-' + subcatLabel.id.split('-')[1];
-    displayNewSubcats($(subcatGroup), subcatLabel.value);
-    uncheckAll();
+    var subcatGroup = '#js-subcategory-group-' + subcatLabel.id.split('-')[1]
+    displayNewSubcats($(subcatGroup), subcatLabel.value)
+    uncheckAll()
 
     if (subcatLabel.value !== '') {
-      $('#js-add-another-container').removeClass('hidden');
+      $('#js-add-another-container').removeClass('hidden')
     } else if (subcatLabel.value === '' && categoryId === 1) {
-      $('#js-add-another-container').addClass('hidden');
+      $('#js-add-another-container').addClass('hidden')
     }
+  }
+
+  // New function to handle forcing the value to Select All
+  function showSubcatsOnValidation (subcatLabel, value) {
+    $('#js-categories-container .col-sm-12').remove()
+    var subcatGroup = '#js-subcategory-group-' + subcatLabel.id.split('-')[1]
+    displayNewSubcats($(subcatGroup), value)
+
+    if (subcatLabel.value !== '') {
+      $('#js-add-another-container').removeClass('hidden')
+    } else if (subcatLabel.value === '' && categoryId === 1) {
+      $('#js-add-another-container').addClass('hidden')
+    }
+
   }
 
   function generateNewSubcats () {
     $('.js-category-select').change(function () {
-      showSubcats(this);
-    });
+      showSubcats(this)
+    })
+
   }
 
-  generateNewSubcats();
+  // This forces the form into "select all" so it can easy display all the subcategories which are checked and unchecked
+  if (selectedSubCategories.length > 0) {
+    showSubcatsOnValidation($('.js-category-select')[0], 'Select All')
 
-  $(addAnother).click(function () {
-    var categorySelect = '<option value="">-- Choose One --</option>';
+  } else {
+    generateNewSubcats()
 
-    $.each(categories, function (ix, value) {
-      categorySelect += '<option value="' + value + '">' + value + '</option>';
-    });
+    $(addAnother).click(function () {
+      var categorySelect = '<option value="">-- Choose One --</option>'
 
-    categoriesContainer.append('<div class="form-group">' +
-      '<div class="col-sm-12">' +
+      $.each(categories, function (ix, value) {
+        categorySelect += '<option value="' + value + '">' + value + '</option>'
+
+      })
+
+      categoriesContainer.append('<div class="form-group">' +
+        '<div class="col-sm-12">' +
         '<select class="form-control col-sm-12 js-category-select" id="categories-' + categoryId + '" name="categories-' + categoryId + '">' +
-      categorySelect +
+        categorySelect +
         '</select>' +
-      '</div>' +
-    '</div>' +
-    '<div class="form-group" id="js-subcategory-group-' + categoryId + '">' +
-    '</div>');
+        '</div>' +
+        '</div>' +
+        '<div class="form-group" id="js-subcategory-group-' + categoryId + '">' +
+        '</div>')
 
-    var newCategory = $('#categories-' + categoryId);
+      var newCategory = $('#categories-' + categoryId)
 
-    displayNewSubcats($('#js-subcategory-group-' + categoryId), newCategory.val());
+      displayNewSubcats($('#js-subcategory-group-' + categoryId), newCategory.val())
 
-    categoryId += 1;
+      categoryId += 1
 
-    generateNewSubcats();
-    uncheckAll();
+      generateNewSubcats()
+      uncheckAll()
 
-  });
+    })
 
-  var initCategorySelect = $('.js-category-select');
+    var initCategorySelect = $('.js-category-select')
 
-  if (initCategorySelect.length > 0 && initCategorySelect !== '---') {
-    showSubcats($('.js-category-select')[0]);
+    if (initCategorySelect.length > 0 && initCategorySelect !== '---') {
+      showSubcats($('.js-category-select')[0])
+    }
   }
-
-})();
+})()

--- a/beacon/templates/beacon/admin/opportunity.html
+++ b/beacon/templates/beacon/admin/opportunity.html
@@ -158,5 +158,6 @@
 <script type="text/javascript">
   var subcategories = {{ subcategories|safe }};
   var categories = {{ categories|safe }};
+  var selectedSubCategories = {{ selected_subcategories|safe }};
 </script>
 {% endblock %}

--- a/beacon/templates/beacon/front/signup.html
+++ b/beacon/templates/beacon/front/signup.html
@@ -110,5 +110,6 @@
 <script type="text/javascript">
   var subcategories = {{ subcategories|safe }};
   var categories = {{ categories|safe }};
+  var selectedSubCategories = {{ selected_subcategories|safe }};
 </script>
 {% endblock %}


### PR DESCRIPTION
In reference to Issue #3 

On both the opportunity creation form, and vendor signup form, the form will now retain the POST data values for category/subcategory choices if you have a validation error on another field. 

Because the select / checkbox button UI allowed for all sorts of weird scenarios (including double selection of the same fields), I didn't think it was worth replicating the exact configuration of your selection. (If this doesn't make sense, I'll show you on screenshare.) Rather, now, if you return to the form after a validation error on another field, all the checkbox options are there, with your values checked. 

Happy to discuss. 
